### PR TITLE
patched step counter for evals

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -238,6 +238,7 @@ def get_wds_dataset(args, image_processor, tokenizer, epoch=0, floor=False):
     resampled = getattr(args, 'dataset_resampled', False)
 
     num_samples, num_shards = get_dataset_size(input_shards)
+    num_samples = None
     if not num_samples:
         num_samples = args.train_num_samples
         if not num_samples:

--- a/src/train.py
+++ b/src/train.py
@@ -58,7 +58,7 @@ def main():
     parser.add_argument("--delete_previous_checkpoint", action="store_true",
      help="delete previous checkpoint when saving new checkpoint")
     parser.add_argument(
-        "--shards", type=str, default="/data/yfcc-tmp/cah/shards/shard_{000000..053008}.tar")
+        "--shards", type=str, default="/data/yfcc-tmp/yfcc/chunks_merged_1e3/shard_{00000..14825}.tar")
     parser.add_argument("--eval_coco_data_dir", type=str,
                         default="/data/yfcc-tmp/data/mscoco")
     parser.add_argument("--eval_okvqa_data_dir", type=str,
@@ -215,17 +215,17 @@ def main():
                         wandb=wandb)
 
         if args.do_eval and args.rank == 0:
+            step = wandb.run.step if args.report_to_wandb else 0
             score = evaluate_coco(ddp_model, tokenizer, image_processor,
                                   data_dir=args.eval_coco_data_dir,
                                   batch_size=args.batch_size,
                                   num_samples=5000,
                                   device=device_id,
                                   wandb=wandb if args.report_to_wandb else None,
-                                  step=(epoch+1)*train_loader.num_batches)
+                                  step=step)
 
             if args.report_to_wandb:
-                wandb.log(score, step=(epoch+1) *
-                          train_loader.num_batches, commit=False)
+                wandb.log(score, step=step, commit=False)
 
             vqa_score = evaluate_vqa(ddp_model, tokenizer, image_processor, benchmark_name="OKVQA",
                                      data_dir=args.eval_okvqa_data_dir,
@@ -233,11 +233,10 @@ def main():
                                      num_samples=5000,
                                      device=device_id,
                                      wandb=wandb if args.report_to_wandb else None,
-                                     step=(epoch+1)*train_loader.num_batches)
+                                     step=step)
 
             if args.report_to_wandb:
-                wandb.log(vqa_score, step=(epoch+1) *
-                          train_loader.num_batches, commit=True)
+                wandb.log(vqa_score, step=step, commit=True)
 
             ddp_model.train()
         


### PR DESCRIPTION
Fixed a bug which prevented evaluations from logging to wandb. This is not a perfect fix as it increments the wandb step at different rate to the global step counter but it gets the job done for now especially since we don't eval for the larger training runs so we wouldn't hit this case.