### PR TITLE
Added option to use projection for vision_x

### DIFF
--- a/open_flamingo/src/flamingo.py
+++ b/open_flamingo/src/flamingo.py
@@ -34,7 +34,7 @@ class Flamingo(nn.Module):
         self.vis_dim = (
             vis_dim
             if vis_dim is not None
-            else vision_encoder.config.vision_config.hidden_size
+            else vision_encoder.config.projection_dim
         )
 
         self.vision_encoder = vision_encoder

--- a/open_flamingo/train/data.py
+++ b/open_flamingo/train/data.py
@@ -276,9 +276,9 @@ def preprocess_pile(sample, tokenizer, clip_processor):
     if len(sentences) == 0:
         raise ValueError("No sentences in sample")
 
-    # replace sentences 70% of the time
     indices_replaced = torch.zeros(len(sentences), dtype=torch.bool)
-    indices_replaced[torch.rand(len(sentences)) <= 0.7] = True
+    # replace 100% of sentences this is bad code atm and should be changed
+    indices_replaced[torch.rand(len(sentences)) <= 1.0] = True 
 
     if indices_replaced.sum() == 0:
         raise ValueError("No sentences to mask")

--- a/open_flamingo/train/train_utils.py
+++ b/open_flamingo/train/train_utils.py
@@ -123,7 +123,7 @@ def train_one_epoch(
                 attention_mask=attention_mask,
                 labels=labels,
                 pseudovision_x=clip_text_input_ids,
-                pseudovision_mask=clip_text_attention_mask,
+                pseudovision_attention_mask=clip_text_attention_mask,
             )[0]
         divided_loss_pile = loss_pile / args.gradient_accumulation_steps
 


### PR DESCRIPTION
* Added use_projection_vector argument to use the CLIP projection output for vision features.
* We decided to use the resampler for both patch embeddings and projection vectors.

TODO:
[ ] Doing a small training run to make sure everything looks right.