### PR TITLE
add conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: openflamingo
+channels:
+  - defaults
+dependencies:
+  - python=3.9
+  - pip
+  - pip:
+    - -r requirements.txt
+    - -e .


### PR DESCRIPTION
Sets up a basic conda environment to ensure cross-platform reproducibility.