### PR TITLE
Fix default vis_dim

### DIFF
--- a/open_flamingo/src/flamingo.py
+++ b/open_flamingo/src/flamingo.py
@@ -34,7 +34,7 @@ class Flamingo(nn.Module):
         self.vis_dim = (
             vis_dim
             if vis_dim is not None
-            else vision_encoder.config.projection_dim
+            else vision_encoder.config.vision_config.hidden_size
         )
 
         self.vision_encoder = vision_encoder


### PR DESCRIPTION
The default vis_dim should be the vision_encoder's hidden_size rather than projection_dim