### PR TITLE
Adding evaluation: VizWiz + TextVQA + fixing image loading bug

### DIFF
--- a/open_flamingo/eval/eval_datasets.py
+++ b/open_flamingo/eval/eval_datasets.py
@@ -63,6 +63,10 @@ class VQADataset(Dataset):
             return os.path.join(
                 self.image_dir_path, f"COCO_val2014_{question['image_id']:012d}.jpg"
             )
+        elif self.vqa_dataset == 'vizwiz':
+            return os.path.join(self.image_dir_path, question['image_id'])
+        elif self.vqa_dataset == 'textvqa':
+            return os.path.join(self.image_dir_path, f"{question['image_id']}.jpg")
         else:
             raise Exception(f"Unknown VQA dataset {self.vqa_dataset}")
 
@@ -71,6 +75,7 @@ class VQADataset(Dataset):
         answers = self.answers[idx]
         img_path = self.get_img_path(question)
         image = Image.open(img_path)
+        image.load()
         return {
             "image": image,
             "question": question["question"],

--- a/open_flamingo/eval/evaluate.py
+++ b/open_flamingo/eval/evaluate.py
@@ -84,6 +84,18 @@ parser.add_argument(
     help="Whether to evaluate on OK-VQA.",
 )
 parser.add_argument(
+    "--eval_vizwiz",
+    action="store_true",
+    default=False,
+    help="Whether to evaluate on VizWiz.",
+)
+parser.add_argument(
+    "--eval_textvqa",
+    action="store_true",
+    default=False,
+    help="Whether to evaluate on TextVQA.",
+)
+parser.add_argument(
     "--eval_imagenet",
     action="store_true",
     default=False,
@@ -163,12 +175,53 @@ parser.add_argument(
     default=None,
 )
 
+## VizWiz Dataset
+parser.add_argument(
+    "--vizwiz_image_dir_path",
+    type=str,
+    help="Path to the vizwiz validation images directory.",
+    default=None,
+)
+parser.add_argument(
+    "--vizwiz_questions_json_path",
+    type=str,
+    help="Path to the vizwiz questions json file.",
+    default=None,
+)
+parser.add_argument(
+    "--vizwiz_annotations_json_path",
+    type=str,
+    help="Path to the vizwiz annotations json file.",
+    default=None,
+)
+
+# TextVQA Dataset
+parser.add_argument(
+    "--textvqa_image_dir_path",
+    type=str,
+    help="Path to the textvqa images directory.",
+    default=None,
+)
+parser.add_argument(
+    "--textvqa_questions_json_path",
+    type=str,
+    help="Path to the textvqa questions json file.",
+    default=None,
+)
+parser.add_argument(
+    "--textvqa_annotations_json_path",
+    type=str,
+    help="Path to the textvqa annotations json file.",
+    default=None,
+)
+
 ## Imagenet dataset
 parser.add_argument("--imagenet_root", type=str, default="/tmp")
 
 
 def main():
     args = parser.parse_args()
+    print(f"batch_size: {args.batch_size}")
 
     # load model
     flamingo, image_processor, tokenizer = create_model_and_transforms(
@@ -287,6 +340,58 @@ def main():
                 {"shots": shot, "trials": scores, "mean": np.mean(scores)}
             )
 
+    if args.eval_vizwiz:
+        print("Evaluating on VizWiz...")
+        for shot in args.shots:
+            scores = []
+            for seed, trial in zip(args.trial_seeds, range(args.num_trials)):
+                vizwiz_score = evaluate_vqa(
+                    model=flamingo,
+                    tokenizer=tokenizer,
+                    image_processor=image_processor,
+                    batch_size=args.batch_size,
+                    num_samples=args.num_samples,
+                    num_shots=shot,
+                    device=args.device,
+                    seed=seed,
+                    image_dir_path=args.vizwiz_image_dir_path,
+                    questions_json_path=args.vizwiz_questions_json_path,
+                    annotations_json_path=args.vizwiz_annotations_json_path,
+                    vqa_dataset="vizwiz",
+                )
+                print(f"Shots {shot} Trial {trial} VizWiz score: {vizwiz_score}")
+                scores.append(vizwiz_score)
+            print(f"Shots {shot} Mean VizWiz score: {np.mean(scores)}")
+            results["vizwiz"].append(
+                {"shots": shot, "trials": scores, "mean": np.mean(scores)}
+            )
+
+    if args.eval_textvqa:
+        print("Evaluating on TextVQA...")
+        for shot in args.shots:
+            scores = []
+            for seed, trial in zip(args.trial_seeds, range(args.num_trials)):
+                textvqa_score = evaluate_vqa(
+                    model=flamingo,
+                    tokenizer=tokenizer,
+                    image_processor=image_processor,
+                    batch_size=args.batch_size,
+                    num_samples=args.num_samples,
+                    num_shots=shot,
+                    device=args.device,
+                    seed=seed,
+                    image_dir_path=args.textvqa_image_dir_path,
+                    questions_json_path=args.textvqa_questions_json_path,
+                    annotations_json_path=args.textvqa_annotations_json_path,
+                    vqa_dataset="textvqa",
+                )
+                print(f"Shots {shot} Trial {trial} TextVQA score: {textvqa_score}")
+                scores.append(textvqa_score)
+            print(f"Shots {shot} Mean TextVQA score: {np.mean(scores)}")
+            results["textvqa"].append(
+                {"shots": shot, "trials": scores, "mean": np.mean(scores)}
+            )
+
     if args.eval_imagenet:
         print("Evaluating on ImageNet...")
         for shot in args.shots:
@@ -320,7 +425,7 @@ def main():
 def get_random_indices(num_samples, query_set_size, full_dataset, seed):
     if num_samples + query_set_size > len(full_dataset):
         raise ValueError(
-            f"num_samples + num_shots must be less than {len(full_dataset)}"
+            f"num_samples + query_set_size must be less than {len(full_dataset)}"
         )
 
     # get a random subset of the dataset
@@ -587,7 +692,7 @@ def evaluate_vqa(
     vqa_dataset="vqa",
 ):
     """
-    Evaluate a model on VQA datasets. Currently supports VQA v2.0.
+    Evaluate a model on VQA datasets. Currently supports VQA v2.0, OK-VQA, VizWiz and TextVQA.
 
     Args:
         model (nn.Module): model to evaluate
@@ -619,7 +724,6 @@ def evaluate_vqa(
     )
 
     effective_num_shots = num_shots if num_shots > 0 else 2
-
     if num_samples + effective_num_shots > len(full_dataset):
         raise ValueError(
             f"num_samples + num_shots must be less than or equal to {len(full_dataset)}"

--- a/open_flamingo/eval/evaluate.py
+++ b/open_flamingo/eval/evaluate.py
@@ -221,7 +221,6 @@ parser.add_argument("--imagenet_root", type=str, default="/tmp")
 
 def main():
     args = parser.parse_args()
-    print(f"batch_size: {args.batch_size}")
 
     # load model
     flamingo, image_processor, tokenizer = create_model_and_transforms(

--- a/open_flamingo/eval/vqa_metric.py
+++ b/open_flamingo/eval/vqa_metric.py
@@ -197,7 +197,8 @@ class VQA:
             qaAnn = self.qa[quesId]
             ann["image_id"] = qaAnn["image_id"]
             ann["question_type"] = qaAnn["question_type"]
-            ann["answer_type"] = qaAnn["answer_type"]
+            if 'answer_type' in ann:
+                ann["answer_type"] = qaAnn["answer_type"]
         print(
             "DONE (t=%0.2fs)" % ((datetime.datetime.utcnow() - time_t).total_seconds())
         )
@@ -425,7 +426,7 @@ class VQAEval:
                 acc = min(1, float(len(matchingAns)) / 3)
                 gtAcc.append(acc)
             quesType = gts[quesId]["question_type"]
-            ansType = gts[quesId]["answer_type"]
+            ansType = gts[quesId]["answer_type"] if 'answer_type' in gts[quesId] else "other"
             avgGTAcc = float(sum(gtAcc)) / len(gtAcc)
             accQA.append(avgGTAcc)
             if quesType not in accQuesType:


### PR DESCRIPTION
1. Fixing the bug from [this issue](https://github.com/mlfoundations/open_flamingo/issues/148) by adding `image.load()` after opening the image.

2. Adding evaluation dataset VizWiz + TextVQA.
The method was to convert the datasets to the VQA format, jsons of questions and annotations, to make fewer edits in the evaluation code. 
Questions + Annotations are available [in this drive](https://drive.google.com/drive/folders/1fUsHqCCJ8oJ2u4EEIyeoNSvCYPo2uf36?usp=sharing). 
VizWiz Images: https://vizwiz.cs.colorado.edu/VizWiz_final/images/val.zip
TextVQA Images: the attached drive script `download_textvqa_images.py` allows to download
There are also bash files: `run_eval_vizwiz.sh` and `run_eval_textvqa.sh` to run the evaluations. 

Example addition for the [original eval script](https://github.com/mlfoundations/open_flamingo/blob/main/open_flamingo/scripts/run_eval.sh) (all described in the attached bash files):
```bash
VIZWIZ_IMG_PATH="${SERVER_DIR}/VizWiz/val"
VIZWIZ_ANNO_PATH="${SERVER_DIR}/VizWiz/Annotations/val_annotations_vqa_format.json"
VIZWIZ_QUESTION_PATH="${SERVER_DIR}/VizWiz/Annotations/val_questions_vqa_format.json"

python open_flamingo/eval/evaluate.py \
    --lm_path $LM_PATH \
    --lm_tokenizer_path $LM_TOKENIZER_PATH \
    ...
    ...
    --vizwiz_image_dir_path $VIZWIZ_IMG_PATH \
    --vizwiz_annotations_json_path $VIZWIZ_ANNO_PATH \
    --vizwiz_questions_json_path $VIZWIZ_QUESTION_PATH \
    --results_file $RESULTS_FILE \
    --eval_textvqa \
    ...
```