### PR TITLE
updated to use version of transformers with llama

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ conda env create -f environment.yml
 # Usage
 We provide an initial [OpenFlamingo 9B model](https://huggingface.co/openflamingo/OpenFlamingo-9B) using a CLIP ViT-Large vision encoder and a LLaMA-7B language model. In general, we support any [CLIP vision encoder](https://huggingface.co/models?search=clip). For the language model, we support [LLaMA](https://huggingface.co/models?search=llama), [OPT](https://huggingface.co/models?search=opt), [GPT-Neo](https://huggingface.co/models?search=gpt-neo), [GPT-J](https://huggingface.co/models?search=gptj), and [Pythia](https://huggingface.co/models?search=pythia) models.
 
-#### NOTE: To use LLaMA models, you will need to install the latest version of transformers via
-```
-pip install git+https://github.com/huggingface/transformers
-```
-Use this [script](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/convert_llama_weights_to_hf.py) for converting LLaMA weights to HuggingFace format.
+NOTE: To use LLaMA models, you will need to use this [script](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/convert_llama_weights_to_hf.py) for converting LLaMA weights to HuggingFace format.
 
 ## Initializing an OpenFlamingo model
 ``` python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 einops
 einops-exts
-transformers
+transformers>=4.28.1
 torch
 torchvision
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ nltk
 scipy
 inflection
 sentencepiece
-open_clip_torch
+open_clip_torch>=2.16.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     REQUIREMENTS = [
         "einops",
         "einops-exts",
-        "transformers",
+        "transformers>=4.28.1",
         "torch",
         "torchvision",
         "pillow",
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         name="open_flamingo",
         packages=find_packages(),
         include_package_data=True,
-        version="0.0.2",
+        version="0.0.3",
         license="MIT",
         description="An open-source framework for training large multimodal models",
         long_description=long_description,


### PR DESCRIPTION
Updated requirements.txt and readme to use the 4.28.1 version of transformers at a minimum as that is released to pypi and has llama implementation.

Edit: Also updated minimum open clip version.