### PR TITLE
Update code to be compatible with released version of mmc4 (CLIP features instead of images)

### DIFF
--- a/open_flamingo/scripts/download_mmc4.sh
+++ b/open_flamingo/scripts/download_mmc4.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+  echo "Please provide the destination folder as an argument."
+  echo "Usage: ./download_mmc4.sh /path/to/destination/folder"
+  exit 1
+fi
+
+# Set the download URL base
+URL_BASE="https://storage.googleapis.com/ai2-jackh-mmc4-public/data_core/docs_no_face_shard_"
+CLIP_URL_BASE="https://storage.googleapis.com/ai2-jackh-mmc4-public/images/clip_vitl14_shard_"
+
+# Set the folder where you want to save the unzipped files
+DESTINATION_FOLDER="$1"
+
+# Create the destination folder if it doesn't exist
+mkdir -p "$DESTINATION_FOLDER"
+
+# Loop through the shard numbers and download and unzip the files
+for SHARD in {0..23098}; do
+  # JSONL DATA
+  URL="${URL_BASE}${SHARD}_v3.jsonl.zip"
+  ZIP_FILE="${DESTINATION_FOLDER}/shard_${SHARD}.zip"
+  echo "Downloading shard $SHARD from $URL..."
+
+  # Download the file (continue if the file is missing or there is an error)
+  curl -fsSL --retry 3 --retry-delay 5 --max-time 20 --continue-at - "$URL" -o "$ZIP_FILE" || echo "Error downloading shard $SHARD, continuing..."
+
+  # CLIP DATA
+  CLIP_URL="${CLIP_URL_BASE}${SHARD}_features.pkl"
+  CLIP_DEST="${DESTINATION_FOLDER}/shard_${SHARD}_features.pkl"
+
+  # Download the file (continue if the file is missing or there is an error)
+  curl -fsSL --retry 3 --retry-delay 5 --max-time 20 --continue-at - "$CLIP_URL" -o "$CLIP_DEST" || echo "Error downloading features for shard $SHARD, continuing..."
+done
+
+echo "Download and unzip process completed."

--- a/open_flamingo/src/factory.py
+++ b/open_flamingo/src/factory.py
@@ -66,8 +66,8 @@ def create_model_and_transforms(
         lang_encoder,
         text_tokenizer.encode("<|endofchunk|>")[-1],
         text_tokenizer.encode("<image>")[-1],
-        vis_dim=open_clip.get_model_config(clip_vision_encoder_path)["vision_cfg"][
-            "width"
+        vis_dim=open_clip.get_model_config(clip_vision_encoder_path)[
+            "embed_dim"
         ],
         cross_attn_every_n_layers=cross_attn_every_n_layers,
         **flamingo_kwargs,

--- a/open_flamingo/src/flamingo.py
+++ b/open_flamingo/src/flamingo.py
@@ -189,7 +189,7 @@ class Flamingo(nn.Module):
 
         vision_x = rearrange(vision_x, "b T F c h w -> (b T F) c h w")
         with torch.no_grad():
-            vision_x = self.vision_encoder.visual(vision_x)[1]
+            vision_x = self.vision_encoder.encode_image(vision_x).unsqueeze(1) # b d -> b v d
         vision_x = rearrange(vision_x, "(b T F) v d -> b T F v d", b=b, T=T, F=F)
 
         vision_x = self.perceiver(vision_x)  # reshapes to (b, T, n, d)

--- a/open_flamingo/src/flamingo.py
+++ b/open_flamingo/src/flamingo.py
@@ -193,7 +193,7 @@ class Flamingo(nn.Module):
             # images
             vision_x = rearrange(vision_x, "b T F c h w -> (b T F) c h w")
             with torch.no_grad():
-                vision_x = self.vision_encoder.encode_image(vision_x).unsqueeze(1) # b d -> b v d
+                vision_x = self.vision_encoder.encode_image(vision_x)[0].unsqueeze(1) # b d -> b v d
             vision_x = rearrange(vision_x, "(b T F) v d -> b T F v d", b=b, T=T, F=F)
 
         else:


### PR DESCRIPTION
Added:
- mmc4 download script `download_mmc4.sh`

Updated:
- `convert_mmc4_to_wds.py`. CLIP features are saved directly into the json under the key `clip_features`
- `data.py` to load CLIP features
- main Flamingo model to use projection features (`vis_dim=768`), since released mmc4 features are all projection features
- `model._encode_vision_x()` logic to accept either raw images (from LAION) or CLIP features (from mmc4)