### PR TITLE
Add BLIP-2 to eval suite

### DIFF
--- a/open_flamingo/eval/evaluate.py
+++ b/open_flamingo/eval/evaluate.py
@@ -216,7 +216,11 @@ parser.add_argument(
 def main():
     args, leftovers = parser.parse_known_args()
     module = importlib.import_module(f"open_flamingo.eval.models.{args.model}")
-    eval_model = module.EvalModel(leftovers)
+
+    model_args = {
+        leftovers[i].lstrip("-"): leftovers[i + 1] for i in range(0, len(leftovers), 2)
+    }
+    eval_model = module.EvalModel(model_args)
 
     if args.model != "open_flamingo" and args.shots != [0]:
         raise ValueError("Only 0 shot eval is supported for non-open_flamingo models")
@@ -451,7 +455,7 @@ def evaluate_captioning(
 
             context_text = "".join(
                 [
-                    eval_model.caption_prompt(caption=x["caption"].strip())
+                    eval_model.get_caption_prompt(caption=x["caption"].strip())
                     for x in batch_demo_samples[i]
                 ]
             )
@@ -460,7 +464,7 @@ def evaluate_captioning(
             if num_shots == 0:
                 context_text = context_text.replace("<image>", "")
 
-            batch_text.append(context_text + eval_model.caption_prompt())
+            batch_text.append(context_text + eval_model.get_caption_prompt())
 
         outputs = eval_model.get_outputs(
             batch_images=batch_images,
@@ -593,7 +597,7 @@ def evaluate_vqa(
 
             context_text = "".join(
                 [
-                    eval_model.vqa_prompt(
+                    eval_model.get_vqa_prompt(
                         question=x["question"], answer=x["answers"][0]
                     )
                     for x in batch_demo_samples[i]
@@ -605,7 +609,7 @@ def evaluate_vqa(
                 context_text = context_text.replace("<image>", "")
 
             batch_text.append(
-                context_text + eval_model.vqa_prompt(question=batch[i]["question"])
+                context_text + eval_model.get_vqa_prompt(question=batch[i]["question"])
             )
 
         outputs = eval_model.get_outputs(

--- a/open_flamingo/eval/evaluate.py
+++ b/open_flamingo/eval/evaluate.py
@@ -212,7 +212,7 @@ def main():
     args, leftovers = parser.parse_known_args()
     module = importlib.import_module(f"open_flamingo.eval.models.{args.model}")
     eval_model = module.EvalModel(leftovers)
-    
+
     if args.model != "open_flamingo" and args.shots != [0]:
         raise ValueError("Only 0 shot eval is supported for non-open_flamingo models")
 
@@ -353,10 +353,12 @@ def prepare_eval_samples(test_dataset, num_samples, seed):
 def sample_batch_demos_from_query_set(query_set, num_samples, batch_size):
     return [random.sample(query_set, num_samples) for _ in range(batch_size)]
 
+
 def compute_effective_num_shots(num_shots, model_type):
     if model_type == "open_flamingo":
         return num_shots if num_shots > 0 else 2
     return num_shots
+
 
 def evaluate_captioning(
     args: argparse.Namespace,
@@ -454,7 +456,7 @@ def evaluate_captioning(
                 context_text = context_text.replace("<image>", "")
 
             batch_text.append(context_text + eval_model.caption_prompt())
-        
+
         outputs = eval_model.get_outputs(
             batch_images=batch_images,
             batch_text=batch_text,
@@ -466,7 +468,7 @@ def evaluate_captioning(
         new_predictions = [
             postprocess_captioning_generation(out).replace('"', "") for out in outputs
         ]
-        
+
         for i, sample in enumerate(batch):
             predictions[sample["image_id"]] = {
                 "caption": new_predictions[i],

--- a/open_flamingo/eval/models/blip.py
+++ b/open_flamingo/eval/models/blip.py
@@ -1,0 +1,99 @@
+import argparse
+from typing import List
+
+from PIL import Image
+import torch
+
+from transformers import Blip2Processor, Blip2ForConditionalGeneration
+from open_flamingo.eval.eval_model import BaseEvalModel
+
+class EvalModel(BaseEvalModel):
+    """BLIP-2 model evaluation.
+
+    Attributes:
+      model (nn.Module): Underlying Torch model.
+      tokenizer (transformers.PreTrainedTokenizer): Tokenizer for model.
+      device: Index of GPU to use, or the string "CPU"
+    """
+
+    def __init__(self, args: List[str]):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--lm_path", type=str, default="Salesforce/blip2-flan-t5-xl")
+        parser.add_argument("--processor_path", type=str, default="Salesforce/blip2-flan-t5-xl")
+        parser.add_argument("--device", type=int, default=0)
+        args = parser.parse_args(args)
+
+        # load model
+        self.device = args.device if args.device >= 0 else "cpu"
+        self.processor = Blip2Processor.from_pretrained(args.processor_path)
+        self.model = Blip2ForConditionalGeneration.from_pretrained(
+            args.lm_path
+        )
+        self.model.to(self.device)
+
+    def _prepare_images(self, batch: List[List[torch.Tensor]]) -> torch.Tensor:
+        """Preprocess images and stack them.
+
+        Args:
+            batch: A list of lists of images.
+
+        Returns:
+            A Tensor of shape
+            (batch_size, channels, height, width).
+        """
+        batch_images = None
+        assert all(
+            len(example) == 1 for example in batch
+        ), "BLIP-2 only supports one image per example"
+        
+        for example in batch:
+            assert len(example) == 1, "BLIP-2 only supports one image per example"
+            batch_images = torch.cat(
+                [batch_images, self.processor.image_processor(example, return_tensors="pt")["pixel_values"]]
+                if batch_images is not None
+                else [self.processor.image_processor(example, return_tensors="pt")["pixel_values"]],
+                dim=0,
+            )
+        return batch_images
+
+    def get_outputs(
+        self,
+        batch_text: List[str],
+        batch_images: List[List[Image.Image]],
+        max_generation_length: int,
+        num_beams: int,
+        length_penalty: float,
+    ) -> List[str]:
+        self.model.eval()
+
+        self.processor.tokenizer.padding_side = "left"
+        encodings = self.processor.tokenizer(
+            batch_text,
+            padding="longest",
+            truncation=True,
+            return_tensors="pt",
+            max_length=2000,
+        )
+        input_ids = encodings["input_ids"]
+        attention_mask = encodings["attention_mask"]
+
+        with torch.inference_mode():
+            outputs = self.model.generate(
+                self._prepare_images(batch_images).to(self.device),
+                input_ids.to(self.device),
+                attention_mask=attention_mask.to(self.device),
+                max_new_tokens=max_generation_length,
+                num_beams=num_beams,
+                length_penalty=length_penalty,
+            )
+
+        return self.processor.tokenizer.batch_decode(outputs, skip_special_tokens=True)
+
+    def vqa_prompt(self, question, answer=None) -> str:
+        return f"Question:{question} Short answer:{answer if answer is not None else ''}"
+
+    def caption_prompt(self, caption=None) -> str:
+        return f"A photo of {caption if caption is not None else ''}"
+
+    def classification_prompt(self, class_str=None) -> str:
+        raise NotImplementedError

--- a/open_flamingo/eval/models/blip.py
+++ b/open_flamingo/eval/models/blip.py
@@ -7,6 +7,7 @@ import torch
 from transformers import Blip2Processor, Blip2ForConditionalGeneration
 from open_flamingo.eval.eval_model import BaseEvalModel
 
+
 class EvalModel(BaseEvalModel):
     """BLIP-2 model evaluation.
 
@@ -18,17 +19,19 @@ class EvalModel(BaseEvalModel):
 
     def __init__(self, args: List[str]):
         parser = argparse.ArgumentParser()
-        parser.add_argument("--lm_path", type=str, default="Salesforce/blip2-flan-t5-xl")
-        parser.add_argument("--processor_path", type=str, default="Salesforce/blip2-flan-t5-xl")
+        parser.add_argument(
+            "--lm_path", type=str, default="Salesforce/blip2-flan-t5-xl"
+        )
+        parser.add_argument(
+            "--processor_path", type=str, default="Salesforce/blip2-flan-t5-xl"
+        )
         parser.add_argument("--device", type=int, default=0)
         args = parser.parse_args(args)
 
         # load model
         self.device = args.device if args.device >= 0 else "cpu"
         self.processor = Blip2Processor.from_pretrained(args.processor_path)
-        self.model = Blip2ForConditionalGeneration.from_pretrained(
-            args.lm_path
-        )
+        self.model = Blip2ForConditionalGeneration.from_pretrained(args.lm_path)
         self.model.to(self.device)
 
     def _prepare_images(self, batch: List[List[torch.Tensor]]) -> torch.Tensor:
@@ -45,13 +48,22 @@ class EvalModel(BaseEvalModel):
         assert all(
             len(example) == 1 for example in batch
         ), "BLIP-2 only supports one image per example"
-        
+
         for example in batch:
             assert len(example) == 1, "BLIP-2 only supports one image per example"
             batch_images = torch.cat(
-                [batch_images, self.processor.image_processor(example, return_tensors="pt")["pixel_values"]]
+                [
+                    batch_images,
+                    self.processor.image_processor(example, return_tensors="pt")[
+                        "pixel_values"
+                    ],
+                ]
                 if batch_images is not None
-                else [self.processor.image_processor(example, return_tensors="pt")["pixel_values"]],
+                else [
+                    self.processor.image_processor(example, return_tensors="pt")[
+                        "pixel_values"
+                    ]
+                ],
                 dim=0,
             )
         return batch_images
@@ -90,7 +102,9 @@ class EvalModel(BaseEvalModel):
         return self.processor.tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
     def vqa_prompt(self, question, answer=None) -> str:
-        return f"Question:{question} Short answer:{answer if answer is not None else ''}"
+        return (
+            f"Question:{question} Short answer:{answer if answer is not None else ''}"
+        )
 
     def caption_prompt(self, caption=None) -> str:
         return f"A photo of {caption if caption is not None else ''}"

--- a/open_flamingo/eval/models/open_flamingo.py
+++ b/open_flamingo/eval/models/open_flamingo.py
@@ -1,4 +1,3 @@
-import argparse
 from typing import List
 
 from PIL import Image
@@ -17,38 +16,35 @@ class EvalModel(BaseEvalModel):
       device: Index of GPU to use, or the string "CPU"
     """
 
-    def __init__(self, args: List[str]):
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--lm_path", type=str, default="facebook/opt-1.3b")
-        parser.add_argument("--lm_tokenizer_path", type=str, default="facebook/opt-30b")
-        parser.add_argument("--vision_encoder_path", default="ViT-L-14", type=str)
-        parser.add_argument("--vision_encoder_pretrained", default="openai", type=str)
-        parser.add_argument("--checkpoint_path", type=str, required=True)
-        parser.add_argument(
-            "--cross_attn_every_n_layers",
-            type=int,
-            default=1,
-            help="how often to add a cross-attention layer after each transformer layer",
-        )
-        parser.add_argument("--device", type=int, default=0)
-        args = parser.parse_args(args)
+    def __init__(self, model_args):
+        assert (
+            "vision_encoder_path" in model_args
+            and "lm_path" in model_args
+            and "device" in model_args
+            and "checkpoint_path" in model_args
+            and "lm_tokenizer_path" in model_args
+            and "cross_attn_every_n_layers" in model_args
+            and "vision_encoder_pretrained" in model_args
+        ), "OpenFlamingo requires vision_encoder_path, lm_path, device, checkpoint_path, lm_tokenizer_path, cross_attn_every_n_layers, and vision_encoder_pretrained arguments to be specified"
 
-        # load model
-        self.device = args.device if args.device >= 0 else "cpu"
+        model_args["device"] = int(model_args["device"])
+        self.device = model_args["device"] if model_args["device"] >= 0 else "cpu"
         (
             self.model,
             self.image_processor,
             self.tokenizer,
         ) = create_model_and_transforms(
-            args.vision_encoder_path,
-            args.vision_encoder_pretrained,
-            args.lm_path,
-            args.lm_tokenizer_path,
-            cross_attn_every_n_layers=args.cross_attn_every_n_layers,
+            model_args["vision_encoder_path"],
+            model_args["vision_encoder_pretrained"],
+            model_args["lm_path"],
+            model_args["lm_tokenizer_path"],
+            cross_attn_every_n_layers=int(model_args["cross_attn_every_n_layers"]),
         )
-        checkpoint = torch.load(args.checkpoint_path, map_location="cpu")
+        checkpoint = torch.load(model_args["checkpoint_path"], map_location="cpu")
         self.model.load_state_dict(checkpoint, strict=False)
         self.model.to(self.device)
+        self.model.eval()
+        self.tokenizer.padding_side = "left"
 
     def _prepare_images(self, batch: List[List[torch.Tensor]]) -> torch.Tensor:
         """Preprocess images and stack them.
@@ -82,9 +78,6 @@ class EvalModel(BaseEvalModel):
         num_beams: int,
         length_penalty: float,
     ) -> List[str]:
-        self.model.eval()
-
-        self.tokenizer.padding_side = "left"
         encodings = self.tokenizer(
             batch_text,
             padding="longest",
@@ -109,11 +102,11 @@ class EvalModel(BaseEvalModel):
 
         return self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
-    def vqa_prompt(self, question, answer=None) -> str:
+    def get_vqa_prompt(self, question, answer=None) -> str:
         return f"<image>Question:{question} Short answer:{answer if answer is not None else ''}{'<|endofchunk|>' if answer is not None else ''}"
 
-    def caption_prompt(self, caption=None) -> str:
+    def get_caption_prompt(self, caption=None) -> str:
         return f"<image>Output:{caption if caption is not None else ''}{'<|endofchunk|>' if caption is not None else ''}"
 
-    def classification_prompt(self, class_str=None) -> str:
+    def get_classification_prompt(self, class_str=None) -> str:
         return f"<image>A photo of a {class_str if class_str is not None else ''}{'<|endofchunk|>' if class_str is not None else ''}"

--- a/open_flamingo/eval/ok_vqa_utils.py
+++ b/open_flamingo/eval/ok_vqa_utils.py
@@ -209,6 +209,6 @@ stemmer = OKVQAStemmer()
 
 
 def postprocess_ok_vqa_generation(predictions) -> str:
-    prediction = re.split("Question|Answer", predictions, 1)[0]
+    prediction = re.split("Question|Answer|Short", predictions, 1)[0]
     prediction_stem = stemmer.stem(prediction)
     return prediction_stem


### PR DESCRIPTION
Added a BLIP-2 model class to our test bed. This should help to validate that our implementation is correct.

I am able to match the OKVQA and COCO numbers for [BLIP-2 T5-XL](https://huggingface.co/Salesforce/blip2-flan-t5-xl) and [BLIP-2 T5-XL COCO](https://huggingface.co/Salesforce/blip2-flan-t5-xl-coco). I have a VQAv2 evaluation run going that should finish in a bit.

One thing I have noticed is that the new InstructBLIP paper includes Flickr30k numbers for the older models. For some reason our cider scores on Flickr are lower than reported (64 vs 76). I will read the InstructBLIP paper more closely and debug if needed.

Edit: VQAv2 also checks out.