### PR TITLE
fix atten from Long to Bool

### DIFF
--- a/open_flamingo/src/flamingo.py
+++ b/open_flamingo/src/flamingo.py
@@ -110,7 +110,7 @@ class Flamingo(nn.Module):
 
         output = self.lang_encoder(
             input_ids=lang_x,
-            attention_mask=attention_mask,
+            attention_mask=attention_mask > 0,
             labels=labels,
             past_key_values=past_key_values,
             use_cache=use_cache,


### PR DESCRIPTION
If I use `mpt-1b-redpajama-200b` as LM, the attention mask would throw an issue that attention mask should be bool rather than long. 