### PR TITLE
Add Support for Specifying Custom `cache_dir`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,7 @@ wandb
 # Pyre type checker
 .pyre/
 
+# Cache
+cache/
+
 __*.sh

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ model, image_processor, tokenizer = create_model_and_transforms(
     clip_vision_encoder_pretrained="openai",
     lang_encoder_path="anas-awadalla/mpt-1b-redpajama-200b",
     tokenizer_path="anas-awadalla/mpt-1b-redpajama-200b",
-    cross_attn_every_n_layers=1
+    cross_attn_every_n_layers=1,
+    cache_dir="PATH/TO/CACHE/DIR"  # Defaults to ~/.cache
 )
 ```
 

--- a/open_flamingo/src/factory.py
+++ b/open_flamingo/src/factory.py
@@ -40,16 +40,23 @@ def create_model_and_transforms(
         Tokenizer: A tokenizer for the language model
     """
     vision_encoder, _, image_processor = open_clip.create_model_and_transforms(
-        clip_vision_encoder_path, pretrained=clip_vision_encoder_pretrained, cache_dir=cache_dir
+        clip_vision_encoder_path,
+        pretrained=clip_vision_encoder_pretrained,
+        cache_dir=cache_dir,
     )
     # set the vision encoder to output the visual features
     vision_encoder.visual.output_tokens = True
 
     text_tokenizer = AutoTokenizer.from_pretrained(
-        tokenizer_path, local_files_only=use_local_files, trust_remote_code=True, cache_dir=cache_dir
+        tokenizer_path,
+        local_files_only=use_local_files,
+        trust_remote_code=True,
+        cache_dir=cache_dir,
     )
     # add Flamingo special tokens to the tokenizer
-    text_tokenizer.add_special_tokens({"additional_special_tokens": ["<|endofchunk|>", "<image>"]})
+    text_tokenizer.add_special_tokens(
+        {"additional_special_tokens": ["<|endofchunk|>", "<image>"]}
+    )
     if text_tokenizer.pad_token is None:
         # Issue: GPT models don't have a pad token, which we use to
         # modify labels for the loss.
@@ -87,7 +94,9 @@ def create_model_and_transforms(
         lang_encoder,
         text_tokenizer.encode("<|endofchunk|>")[-1],
         text_tokenizer.encode("<image>")[-1],
-        vis_dim=open_clip.get_model_config(clip_vision_encoder_path)["vision_cfg"]["width"],
+        vis_dim=open_clip.get_model_config(clip_vision_encoder_path)["vision_cfg"][
+            "width"
+        ],
         cross_attn_every_n_layers=cross_attn_every_n_layers,
         **flamingo_kwargs,
     )


### PR DESCRIPTION
Hey folks - I love `openflamingo` but a common problem our team has is that saving big files to `~/.cache` vs. other, directories with more space/locations shared with other users.

This PR adds back the `cache_dir` functionality in both OpenCLIP and Hugging Face, allowing one to specify a download location in the call to `create_model_and_transforms`.

I couldn't find `requirements-dev.txt` to run all the linting specified in the Makefile, but ran `black` and `pylint` to (hopefully) conform to the original codebase format.
