### PR TITLE
Unpin sentencepiece version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ transformers>=4.28.1
 torch==2.0.1
 pillow
 open_clip_torch>=2.16.0 
-sentencepiece==0.1.98 
+sentencepiece

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
         "torch==2.0.1",
         "pillow",
         "open_clip_torch>=2.16.0",
-        "sentencepiece==0.1.98",
+        "sentencepiece",
     ]
 
     EVAL = [


### PR DESCRIPTION
Pinning is unnecessary. The only package that require it are torch, transformers, and open_clip.