### PR TITLE
Fix device_id in mmc4 pass

### DIFF
--- a/open_flamingo/train/train_utils.py
+++ b/open_flamingo/train/train_utils.py
@@ -155,8 +155,8 @@ def train_one_epoch(
         with autocast():
             loss_mmc4 = model(
                 vision_x=images,
-                lang_x=input_ids,
-                attention_mask=attention_mask,
+                lang_x=input_ids.to(device_id),
+                attention_mask=attention_mask.to(device_id),
                 labels=labels,
             )[0]
 


### PR DESCRIPTION
Fixes a typo in the forward pass of mmc4 where we weren't moving input_ids and attention_mask to device_id. It is unusual that this was not caught earlier, perhaps it was a merging issue.