### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,3 @@ repos:
     rev: 23.9.1
     hooks:
       - id: black
-      - id: black-jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+---
+default_language_version:
+    python: python3
+
+repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
+    hooks:
+      - id: black
+      - id: black-jupyter

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ There are three `requirements.txt` files:
 
 Depending on your use case, you can install any of these with `pip install -r <requirements-file.txt>`. The base file contains only the dependencies needed for running the model.
 
+## Development
+
+We use pre-commit hooks to align formatting with the checks in the repository. 
+1. To install pre-commit, run
+    ```
+    pip install pre-commit
+    ```
+    or use brew for MacOS
+    ```
+    brew install pre-commit
+    ```
+2. Check the version installed with
+    ```
+    pre-commit --version
+    ```
+3. Then at the root of this repository, run
+    ```
+    pre-commit install
+    ```
+Then every time we run git commit, the checks are run. If the files are reformatted by the hooks, run `git add` for your changed files and `git commit` again
+
 # Approach
 OpenFlamingo is a multimodal language model that can be used for a variety of tasks. It is trained on a large multimodal dataset (e.g. Multimodal C4) and can be used to generate text conditioned on interleaved images/text. For example, OpenFlamingo can be used to generate a caption for an image, or to generate a question given an image and a text passage. The benefit of this approach is that we are able to rapidly adapt to new tasks using in-context learning.
 


### PR DESCRIPTION
- add black as pre-commit hook
- To run
  - First install pre-commit: `pip install pre-commit` (or on mac `brew install pre-commit`)
  - check version with `pre-commit --version`
  - in the root of this repo, run `pre-commit install`
  - Then every time we run `git commit`, the checks are run. If the files are reformatted, git add and git commit again

Note that I've left out the rest of the hooks from [here](https://github.com/run-llama/llama_index/blob/main/.pre-commit-config.yaml) as they are not present in the GH checks.