### PR TITLE
fix for none past_key_values, getting supported tasks

### DIFF
--- a/open_flamingo/eval/eval_models/eval_model.py
+++ b/open_flamingo/eval/eval_models/eval_model.py
@@ -195,7 +195,7 @@ class BaseEvalModel(abc.ABC):
         Parsed by checking whether the model has a method called `get_{task}_prompt`.
         """
         return [
-            task.split("_")[1]
+            "_".join(task.split("_")[1:-1])
             for task in dir(self)
             if task.startswith("get_") and task.endswith("_prompt")
         ]

--- a/open_flamingo/eval/evaluate.py
+++ b/open_flamingo/eval/evaluate.py
@@ -534,7 +534,7 @@ def main():
     if args.eval_coco:
         eval_dataset(
             args,
-            dataset_name="flickr30",
+            dataset_name="coco",
             eval_model=eval_model,
             results=results,
             eval_fn=evaluate_captioning,

--- a/open_flamingo/src/vlm.py
+++ b/open_flamingo/src/vlm.py
@@ -414,13 +414,14 @@ class VLMWithCrossAttention(VLM):
             past_vision_tokens=past_vision_tokens,
             num_beams=num_beams,
         )
-        past_key_values = [
-            (
-                k.repeat_interleave(num_beams, dim=0),
-                v.repeat_interleave(num_beams, dim=0)
-            )
-            for k, v in past_key_values
-        ]
+        if past_key_values is not None: 
+            past_key_values = [
+                (
+                    k.repeat_interleave(num_beams, dim=0),
+                    v.repeat_interleave(num_beams, dim=0)
+                )
+                for k, v in past_key_values
+            ]
         return {
             "input_ids": lang_x,
             "attention_mask": attention_mask,


### PR DESCRIPTION
Current supported_tasks() function does not identify multi-word tasks (e.g. hateful_memes, ok_vqa).