### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 einops
 einops-exts
-transformers>=4.28.1
+transformers==4.28.1
 torch==2.0.1
 pillow
 open_clip_torch>=2.16.0 


### PR DESCRIPTION
The current requirements do not work. The newest version of transformers (4.52), which was installed on my machine with this requirements file requires pytorch>=2.1.0.

The old requirements file is installable, but the code will crash if you try to import the model.

This PR requires the exact version of 4.28.1 which is compatible with pytorch==2.0.1